### PR TITLE
Issue #4 Сделать обязательным аргументом, иначе зачем тогда вызывать Then(). 

### DIFF
--- a/src/Ilya02Il.BaseTypes.Extensions/AsyncExtensions.cs
+++ b/src/Ilya02Il.BaseTypes.Extensions/AsyncExtensions.cs
@@ -50,16 +50,12 @@ namespace Ilya02Il.BaseTypes.Extensions
         ///     как <paramref name="task"/> была отменена
         /// </param>
         public static async Task Then(this Task task,
-            Action onSuccess = default,
+            Action onSuccess,
             Action onCancelled = default)
         {
             try
             {
                 await task;
-
-                if (onSuccess == null)
-                    await Task.CompletedTask;
-
                 onSuccess();
             }
             catch (OperationCanceledException)

--- a/tests/Ilya02Il.BaseTypes.Extensions.Tests/AsyncExtensionsTests.cs
+++ b/tests/Ilya02Il.BaseTypes.Extensions.Tests/AsyncExtensionsTests.cs
@@ -148,7 +148,7 @@ namespace Ilya02Il.BaseTypes.Extensions.Tests
             var task = Task.Delay(10);
             int result = 0;
 
-            await task.Then()
+            await task.Then(() => { })
                 .Catch()
                 .Finally(() => result = 1);
 
@@ -161,7 +161,7 @@ namespace Ilya02Il.BaseTypes.Extensions.Tests
             var task = Task.FromResult(2);
             int result = 0;
 
-            await task.Then()
+            await task.Then(() => { })
                 .Catch()
                 .Finally(() => result = 1);
 


### PR DESCRIPTION
Сделал аргумент onSuccess функции Then обязательным.